### PR TITLE
Update dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -860,4 +860,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "20df95ebc3ee8de9fce7b2e61aba70e3bb76fb18ec1665072a31b87ba06e13d1"
+content-hash = "c5ce6b58e8ce08e3b791c715468dabdbbd57145bc57314b1150fcf9e9c0b2bdc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ imageio = [
   {version = "^2.22.4", markers = "platform_system != 'Linux'"}
 ]
 pillow = "^11.0.0"
-pylint = "^3.3.1"
+pylint = "^3.3.3"
 pytest = "^8.3.3"
 pytest-cov = "^6.0.0"
 


### PR DESCRIPTION
Bump pylint from 3.3.2 to 3.3.3

Bumps [pylint](https://github.com/pylint-dev/pylint) from 3.3.2 to 3.3.3.
- [Release notes](https://github.com/pylint-dev/pylint/releases)
- [Commits](https://github.com/pylint-dev/pylint/compare/v3.3.2...v3.3.3)

---
updated-dependencies:
- dependency-name: pylint dependency-type: direct:development update-type: version-update:semver-patch ...